### PR TITLE
Allow whitespaces in usernames

### DIFF
--- a/component/frontend/models/subscribes.php
+++ b/component/frontend/models/subscribes.php
@@ -317,14 +317,6 @@ class AkeebasubsModelSubscribes extends F0FModel
 			return $ret;
 		}
 
-		// Joomla doens't allow spaces in usernames
-		if (strpos($username, ' ') !== false)
-		{
-			$ret->username = false;
-
-			return $ret;
-		}
-
 		$user = F0FModel::getTmpInstance('Jusers', 'AkeebasubsModel')
 			->username($username)
 			->getFirstItem();


### PR DESCRIPTION
Joomla! supports white spaces in usernames since November 2013: https://github.com/joomla/joomla-cms/pull/2524