### PR TITLE
Subscriptions View: Level title not getting localized

### DIFF
--- a/component/frontend/views/subscriptions/tmpl/default.php
+++ b/component/frontend/views/subscriptions/tmpl/default.php
@@ -103,7 +103,7 @@ if (!property_exists($this, 'extensions'))
 					<?php if ($level->content_url): ?>
 					<a href="<?php echo $this->escape($level->content_url) ?>">
 					<?php endif; ?>
-					<?php echo $this->escape($subscription->title)?>
+					<?php echo $this->escape($level->title)?>
 					<?php if ($level->content_url): ?>
 					</a>
 					<?php endif; ?>


### PR DESCRIPTION
In component/frontend/views/subscriptions/tmpl/default.php
line 106:
<?php echo $this->escape($subscription->title)?>
does not get the localized version of the Level title.

It is displaying the translated version if replaced with:
<?php echo $this->escape($level->title)?>