### PR TITLE
VAT Liability for businesses from the same country as the shop owner country is now not written

### DIFF
--- a/component/backend/config.xml
+++ b/component/backend/config.xml
@@ -249,6 +249,7 @@
 				label="COM_AKEEBASUBS_CONFIG_INVOICE_EXTRACERT_TITLE"
 				description="COM_AKEEBASUBS_CONFIG_INVOICE_EXTRACERT_DESC"
 		/>
+		<field name="invoice_country" type="hidden"	default=""/>
 	</fieldset>
 
   <fieldset name="updates" label="CONFIG_UPDATES_LABEL">

--- a/component/backend/models/invoices.php
+++ b/component/backend/models/invoices.php
@@ -497,7 +497,11 @@ class AkeebasubsModelInvoices extends F0FModel
 
 		$inEU = AkeebasubsHelperEuVATInfo::isEUVATCountry($country);
 
-		if ($inEU && $isbusiness && $viesregistered)
+		// If the shopCountry is the same as the user's country we don't need to put the reverse charge info
+		$shopCountry = AkeebasubsHelperCparams::getParam('invoice_country');
+		$reverse = strcmp($country, $shopCountry) === 0 ? false : true;
+
+		if ($inEU && $isbusiness && $viesregistered && $reverse)
 		{
 			$vat_notice  = AkeebasubsHelperCparams::getParam('invoice_vatnote', 'VAT liability is transferred to the recipient, pursuant EU Directive nr 2006/112/EC and local tax laws implementing this directive.');
 			$cyprus_tag  = 'REVERSE CHARGE';

--- a/component/backend/models/taxconfigs.php
+++ b/component/backend/models/taxconfigs.php
@@ -59,6 +59,9 @@ class AkeebasubsModelTaxconfigs extends F0FModel
 		$euCountries = AkeebasubsHelperEuVATInfo::getEUVATCountries();
 		$inEU        = AkeebasubsHelperEuVATInfo::isEUVATCountry($params->country);
 
+		// Store the country where the business is based (needed for proper invoicing)
+		AkeebasubsHelperCparams::setParam('invoice_country', $params->country);
+
 		// Prototype for tax rules
 		$data     = array(
 			'akeebasubs_level_id'


### PR DESCRIPTION
When a business from the same country as the shop owner's country registers (and both are from the EU) the integrated invoicing is adding the VAT liability information at the bottom of the invoice which is not correct.(the business is being charged VAT and they should not pay VAT again).

That is why I've created a new hidden parameter invoices_country. This parameter is auto-populated when the tax wizard is ran.
Then in the invoicing model we compare the shop owner's country to the current user's country and if all the conditions match, then we'll add the VAT liability info to the invoice. 

Note: the tax wizard needs to be run again. Otherwise the invoices_country parameter will be empty and we'll experience the old behavior. 