### PR TITLE
Bad link in documentation

### DIFF
--- a/documentation/akeebasubs-guide.xml
+++ b/documentation/akeebasubs-guide.xml
@@ -8072,7 +8072,7 @@ Rule C gives $ 30 discount</programlisting>
 
       <note>
         <para>This plugin implements the <link
-        xlink:href="https://www.x.com/developers/paypal/documentation-tools/express-checkout/integration-guide/ECGettingStarted">Express
+        xlink:href="https://developer.paypal.com/docs/classic/express-checkout/gs_expresscheckout/">Express
         Checkout</link> method.</para>
       </note>
 


### PR DESCRIPTION
Bad link to Paypal Express Checkout API in documentation. The existing link goes to a non-existent location.