### PR TITLE
Typo in business name field

### DIFF
--- a/component/backend/views/subscriptions/tmpl/default.php
+++ b/component/backend/views/subscriptions/tmpl/default.php
@@ -304,9 +304,9 @@ $now_timestamp = $jDate->toUnix();
 					<span class="small">[<?php echo $subscription->user_id?>]</span>
 					<br/>
 					<?php echo $this->escape($subscription->name)?>
-					<?php if(!empty($subscription->business_name)):?>
+					<?php if(!empty($subscription->businessname)):?>
 					<br/>
-					<?php echo $this->escape($subscription->business_name)?>
+					<?php echo $this->escape($subscription->businessname)?>
 					&bull;
 					<?php echo $this->escape($subscription->vatnumber)?>
 					<?php endif; ?>


### PR DESCRIPTION
The business name field is called businessname and not business_name. This fixes that and makes the data to show in the list.