### PR TITLE
Slave is still here, use $previous not $current

### DIFF
--- a/plugins/akeebasubs/slavesubs/slavesubs.php
+++ b/plugins/akeebasubs/slavesubs/slavesubs.php
@@ -420,15 +420,15 @@ JS;
 
 				$result = false;
 
-				if (in_array($slave, $current['slaveusers']) && in_array($slave, $previous['slaveusers']))
+				if (in_array($slave, $list['slaveusers']) && in_array($slave, $previous['slaveusers']))
 				{
 					// Slave is still here, just check if his subscription is expired, if so extend it
-					$index = array_search($slave, $current['slaveusers']);
+					$index = array_search($slave, $previous['slaveusers']);
 
-					if(isset($current['slavesubs_ids'][$index]))
+					if(isset($previous['slavesubs_ids'][$index]))
 					{
 						$table = F0FModel::getTmpInstance('Subscriptions', 'AkeebasubsModel')
-									->getItem($current['slavesubs_ids'][$index]);
+									->getItem($previous['slavesubs_ids'][$index]);
 
 						if(!$table->enabled)
 						{


### PR DESCRIPTION
This section of code was looking in the wrong variable for existing slave users breaking the the extend subscription for existing slave subs.
see line 400 and 401 for explanation of $previous and $current variables
The opening check if statement was also broke, as it should check for existing slaveusers being in the merged ($current+$previous) $list array and the $previous array.