### PR TITLE
Slave is still here, just sync with the parent sub

### DIFF
--- a/plugins/akeebasubs/slavesubs/slavesubs.php
+++ b/plugins/akeebasubs/slavesubs/slavesubs.php
@@ -420,23 +420,16 @@ JS;
 
 				$result = false;
 
-				if (in_array($slave, $list['slaveusers']) && in_array($slave, $previous['slaveusers']))
+				if (in_array($slave, $previous['slaveusers']) && in_array($slave, $current['slaveusers']))
 				{
-					// Slave is still here, just check if his subscription is expired, if so extend it
+					// Slave is still here, just sync with the parent subscription
 					$index = array_search($slave, $previous['slaveusers']);
 
 					if(isset($previous['slavesubs_ids'][$index]))
 					{
-						$table = F0FModel::getTmpInstance('Subscriptions', 'AkeebasubsModel')
-									->getItem($previous['slavesubs_ids'][$index]);
-
-						if(!$table->enabled)
-						{
-							$table->save(array('publish_down' => $row->publish_down));
-							$dirty = true;
-						}
-
-						$result = $table->akeebasubs_subscription_id;
+						//we have a valid slave so copy from parent to slave
+						$result =$this->copySubscriptionInformation($row, $previous['slavesubs_ids'][$index]);
+						$dirty = true;	
 					}
 				}
 				elseif(in_array($slave, $current['slaveusers']) && !in_array($slave, $previous['slaveusers']))
@@ -626,8 +619,11 @@ JS;
 			elseif (property_exists($from, $k))
 			{
 				$to->$k = $from->$k;
+				//return the id of the subscription that was modified
+				return $to;
 			}
 		}
+
 	}
 
 	/**


### PR DESCRIPTION
-Utilize the "copySubscriptionInformation" to sync the slave with the parent on modification. We do not care what the state of the slave is in for syncing, just that the slavesub should still exist. 
-Added a return in the copySubscriptionInformation to keep track of what slave sub was modified so the ID can continue to be stored in the parent sub
-Corrected an if statement that on second look should be checking previous vs current (is the user in both to proceed)