### PR TITLE
miscellaneous code changes (on the hunt for cause of 403)

### DIFF
--- a/plugins/akeebasubs/slavesubs/slavesubs.php
+++ b/plugins/akeebasubs/slavesubs/slavesubs.php
@@ -388,8 +388,7 @@ JS;
 			$tableName = '#__akeebasubs_subscriptions';
 			$tableKey = 'akeebasubs_subscription_id';
 			$table = new AkeebasubsTableSubscription($tableName, $tableKey, $db);
-			$table->reset();
-
+			
 			self::$dontFire = true;
 			$table->save($newdata);
 			self::$dontFire = false;
@@ -459,14 +458,14 @@ JS;
 			// Do not try to save the subscription unless we made a change in slave subscribers
 			if (!$dirty)
 			{
-				//return;
+				return;
 			}
 
 			$params['slavesubs_ids'] = $slavesubs_ids;
 			$newdata = array_merge($data, array('params' => json_encode($params), '_dontNotify' => true));
 
-			$table = F0FModel::getTmpInstance('Subscriptions', 'AkeebasubsModel')->getTable();
-			$table->reset();
+			$table = F0FModel::getTmpInstance('Subscriptions', 'AkeebasubsModel')->getItem($data ['akeebasubs_subscription_id']);
+			
 			self::$dontFire = true;
 			$table->save($newdata);
 			self::$dontFire = false;


### PR DESCRIPTION
no need to "$table->reset();" resetting the table index will point to the last saved slave subscription rather than the parent subscription (except when creating a slavesub, since we are creating new table rows)
no need to work with the whole table when a single item will suffice
uncomment the if !dirty "return"
(hunting for the cause of a 403 error in the front end user interface when a subscription is created with an addon user. Getting the wrong sub ID in the URL, rather than the parent ID I keep getting the slave sub ID)