### PR TITLE
if the cache is null, create a null array key for subscriptionlevel

### DIFF
--- a/component/backend/CustomField/Pricedropdown.php
+++ b/component/backend/CustomField/Pricedropdown.php
@@ -30,6 +30,12 @@ class Pricedropdown extends Base
 
 	public function getPerSubscriptionField($item, $cache)
 	{
+		//if $cache['subcustom'] is null or is not an array, make $cache['subcustom'] an empty array
+		if (is_null($cache['subcustom']) || !is_array($cache['subcustom']))
+		{
+			$cache['subcustom'] = array();
+		}
+
 		// Get the current value
 		if (array_key_exists($item->slug, $cache['subcustom']))
 		{

--- a/plugins/akeebasubs/customfields/customfields.php
+++ b/plugins/akeebasubs/customfields/customfields.php
@@ -70,6 +70,10 @@ class plgAkeebasubsCustomfields extends JPlugin
 		// Init the fields array which will be returned
 		$fields = array();
 
+		if ($cache == null) //if the cache is null, create a null array key for subscriptionlevel
+		{
+			$cache['subscriptionlevel'] = null;
+		}
 		// Which subscription level is that?
 		if (!array_key_exists('subscriptionlevel', $cache))
 		{

--- a/plugins/akeebasubs/customfields/customfields.php
+++ b/plugins/akeebasubs/customfields/customfields.php
@@ -69,10 +69,11 @@ class plgAkeebasubsCustomfields extends JPlugin
 
 		// Init the fields array which will be returned
 		$fields = array();
-
-		if ($cache == null) //if the cache is null, create a null array key for subscriptionlevel
+		
+		//if the cache is null, or is not an array... make $cache an array
+		if (is_null($cache) || !is_array($cache)) 
 		{
-			$cache['subscriptionlevel'] = null;
+			$cache = (array) $cache;
 		}
 		// Which subscription level is that?
 		if (!array_key_exists('subscriptionlevel', $cache))


### PR DESCRIPTION
Proposed fix for "Warning: array_key_exists() expects parameter 2 to be array, null given in /administrator/components/com_akeebasubs/CustomField/Pricedropdown.php on line 34"