### PR TITLE
improvements to package build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ All of the following commands are to be run from the MAIN directory.
 	
 		phing link
 		
-	If you are on Windows make sure that you are running an elevated command prompt (run cmd.exe as Administrator or for xampp modify your xampp_shell.bat file to run as administrator by forced UAC)
+	If you are on Windows make sure that you are running an elevated command prompt (run cmd.exe as Administrator)
 	
 ### Useful Phing tasks
 
@@ -71,7 +71,7 @@ or, on Windows:
 	
 or, on Windows:
 	
-	phing relink -Dsite=c:\xampp\htdocs\joomla
+	phing relink -Dsite=c:\path\to\site\root\joomla
 
 #### Relinking internal files
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ All of the following commands are to be run from the MAIN directory.
 	
 		phing link
 		
-	If you are on Windows make sure that you are running an elevated command prompt (run cmd.exe as Administrator)
+	If you are on Windows make sure that you are running an elevated command prompt (run cmd.exe as Administrator or for xampp modify your xampp_shell.bat file to run as administrator by forced UAC)
 	
 ### Useful Phing tasks
 
@@ -85,7 +85,7 @@ This creates the installable ZIP packages of the component inside the MAIN/relea
 
 	phing git
 
-Please note that it's necessary to run `git pull` and `phing git` in your copy of the FOF repository before building an Akeeba Subscriptions package. Failure to do so will either result in an uninstallable package or will end up overwriting the already installed FOF on your site with an older version, resulting in potentially severe issues in other FOF-based components.
+Please note that it's necessary to do a package build for FOF with `git pull` and `phing git`commands in your copy of the FOF repository before building an Akeeba Subscriptions package. For more details see the package build instructions on the [FOF page](https://github.com/akeeba/fof). Failure to do so will either result in a failure to create a package, an uninstallable package or will end up overwriting the already installed FOF on your site with an older version, resulting in potentially severe issues in other FOF-based components.
 	
 #### Build the documentation in PDF format
 


### PR DESCRIPTION
Some helpful hints gleaned from personal experience that a new developer wanting to make a build would like to know. 
- elevated command prompt for xampp can be accomplished by modify your xampp_shell.bat file to run as administrator by forced UAC http://superuser.com/questions/788924/is-it-possible-to-automatically-run-a-batch-file-as-administrator or http://stackoverflow.com/questions/7044985/how-can-i-auto-elevate-my-batch-file-so-that-it-requests-from-uac-administrator 
- see also adding git to xampp https://community.apachefriends.org/f/viewtopic.php?f=16&t=56990
- modify the important note for 'creating a dev release installation package' to be more clear that running the `git pull` and `phing git`commands are part of creating a FOF package before building an Akeeba Subscriptions package.