### PR TITLE
Fatal error: Class not found

### DIFF
--- a/component/backend/Controller/Subscriptions.php
+++ b/component/backend/Controller/Subscriptions.php
@@ -10,6 +10,7 @@ namespace Akeeba\Subscriptions\Admin\Controller;
 defined('_JEXEC') or die;
 
 use FOF30\Controller\DataController;
+use FOF30\Inflector\Inflector;
 
 class Subscriptions extends DataController
 {


### PR DESCRIPTION
The following error occurs when you click "publish" for a user subscription that has a subscription level with custom fields and is currently set to "enabled, no" 

Fatal error: Class 'Akeeba\Subscriptions\Admin\Controller\Inflector' not found in /administrator/components/com_akeebasubs/Controller/Subscriptions.php on line 42

proposed change fixes the error