### PR TITLE
If $custom is null, or is not an array... make $custom an array

### DIFF
--- a/plugins/akeebasubs/agreetoeu/agreetoeu.php
+++ b/plugins/akeebasubs/agreetoeu/agreetoeu.php
@@ -209,6 +209,17 @@ JS;
 
 		$custom = $data->custom;
 
+		// If $custom is null, or is not an array... make $custom an array
+		if (is_null($custom))
+		{
+			$custom = array();
+		}
+
+		if (!is_array($custom))
+ 		{
+ 			$custom = (array) $custom;
+ 		}
+
 		if (!array_key_exists('confirm_informed', $custom))
 		{
 			$custom['confirm_informed'] = 0;

--- a/plugins/akeebasubs/agreetotos/agreetotos.php
+++ b/plugins/akeebasubs/agreetotos/agreetotos.php
@@ -172,7 +172,18 @@ JS;
 		);
 
 		$custom = $data->custom;
+		
+		// If the $custom is null, or is not an array... make $custom an array
+		if (is_null($custom))
+		{
+			$custom = array();
+		}
 
+		if (!is_array($custom))
+ 		{
+ 			$custom = (array) $custom;
+ 		}
+ 		
 		if (!array_key_exists('agreetotos', $custom))
 		{
 			$custom['agreetotos'] = 0;


### PR DESCRIPTION
Proposed change deals with PHP Warning:  array_key_exists() expects parameter 2 to be array, string given in /akeebasubs/agreetotos/agreetotos.php on line 176