### PR TITLE
Class 'AkeebasubsHelperCparams' not found

### DIFF
--- a/component/frontend/View/Subscriptions/tmpl/default.php
+++ b/component/frontend/View/Subscriptions/tmpl/default.php
@@ -20,7 +20,7 @@ if (!property_exists($this, 'extensions'))
 }
 ?>
 
-<?php $summaryimage = AkeebasubsHelperCparams::getParam('summaryimages', 1); ?>
+<?php $summaryimage = ComponentParams::getParam('summaryimages', 1); ?>
 
 <div id="akeebasubs" class="subscriptions">
 	<h2 class="pageTitle"><?php echo JText::_('COM_AKEEBASUBS_SUBSCRIPTIONS_TITLE')?></h2>


### PR DESCRIPTION
Fatal error: Class 'AkeebasubsHelperCparams' not found in /components/com_akeebasubs/View/Subscriptions/tmpl/default.php on line 23

ComponentParams::getParam replaces AkeebasubsHelperCparams::getParam