### PR TITLE
Remove clone from F0FModel in function onAKUserRefresh

### DIFF
--- a/plugins/akeebasubs/slavesubs/slavesubs.php
+++ b/plugins/akeebasubs/slavesubs/slavesubs.php
@@ -492,7 +492,7 @@ JS;
 	public function onAKUserRefresh($user_id)
 	{
 		// Get all of the user's subscriptions
-		$subscriptions = clone F0FModel::getTmpInstance('Subscriptions','AkeebasubsModel')
+		$subscriptions = F0FModel::getTmpInstance('Subscriptions','AkeebasubsModel')
 			->user_id($user_id)
 			->getList();
 


### PR DESCRIPTION
Apparently clone is causing some issues in this one function.
PHP Fatal error:  __clone method called on non-object in /plugins/akeebasubs/slavesubs/slavesubs.php on line 497
PHP Fatal error:  Call to a member function count() on a non-object in /plugins/akeebasubs/slavesubs/slavesubs.php on line 506