### PR TITLE
Added 'use' Statement to include JText

### DIFF
--- a/component/backend/CustomField/Date.php
+++ b/component/backend/CustomField/Date.php
@@ -10,6 +10,7 @@ namespace Akeeba\Subscriptions\Admin\CustomField;
 use Akeeba\Subscriptions\Admin\Model\CustomFields;
 use JText;
 use JFactory;
+use JText;
 
 defined('_JEXEC') or die();
 


### PR DESCRIPTION
There was a fatal error in front end subscription form: 
Fatal error: Class 'Akeeba\Subscriptions\Admin\CustomField\JHTML' not found in [joomla]/administrator/components/com_akeebasubs/CustomField/Date.php on line 49