### PR TITLE
Workaround strict standards error

### DIFF
--- a/component/backend/Model/Subscriptions.php
+++ b/component/backend/Model/Subscriptions.php
@@ -1027,7 +1027,8 @@ class Subscriptions extends DataModel
 	 */
 	public function triggerOnAfterLoad()
 	{
-		$this->onAfterLoad(true, $this->getId());
+		$tmpID = $this->getId();
+		$this->onAfterLoad(true, $tmpID);
 	}
 
 	/**


### PR DESCRIPTION
Line 1030 results in a "Strict standards: Only variables should be passed by reference" error

Signed-off-by: Craig Phillips <craig@craigphillips.biz>