### PR TITLE
Allow to run onAKAfterPaymentCallback always

### DIFF
--- a/plugins/akpayment/paypal/paypal.php
+++ b/plugins/akpayment/paypal/paypal.php
@@ -366,10 +366,10 @@ class plgAkpaymentPaypal extends plgAkpaymentAbstract
 			// the subscription will become P or X and the recurring payment
 			// code above will not run when PayPal sends us a new IPN with the
 			// status set to Completed.
-			return;
+			$updates = null;
 		}
 		// Save the changes
-		$subscription->save($updates);
+		if ($updates) $subscription->save($updates);
 
 		// Run the onAKAfterPaymentCallback events
 		JLoader::import('joomla.plugin.helper');


### PR DESCRIPTION
Run onAKAfterPaymentCallback that plugins could do what they want to.