### PR TITLE
VIES validation improved

### DIFF
--- a/component/backend/Helper/EUVATInfo.php
+++ b/component/backend/Helper/EUVATInfo.php
@@ -182,37 +182,80 @@ abstract class EUVATInfo
 		}
 		else
 		{
-			if (!class_exists('SoapClient'))
-			{
-				$ret = false;
-			}
-			else
+			if (class_exists('SoapClient'))
 			{
 				// Using the SOAP API
 				// Code credits: Angel Melguiz / KMELWEBDESIGN SLNE (www.kmelwebdesign.com)
 				try
 				{
 					$sOptions = array(
-						'user_agent' => 'PHP'
+						'user_agent' => 'PHP',
+						'connection_timeout' => 5,
 					);
-
 					$sClient = new SoapClient('http://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl', $sOptions);
 					$params = array('countryCode' => $prefix, 'vatNumber' => $vat);
-					$response = $sClient->checkVat($params);
 
-					if ($response->valid)
+					for ($i = 0; $i < 2; $i++)
 					{
-						$ret = true;
-					}
-					else
-					{
-						$ret = false;
+						$response = $sClient->checkVat($params);
+						if (is_object($response))
+						{
+							$ret = ($response->valid ? true : false);
+							break;
+						}
+						else
+						{
+							sleep(1);
+						}
 					}
 				}
 				catch (SoapFault $e)
 				{
-					$ret = false;
+
 				}
+			}
+
+			if ($ret === null)
+			{
+				try
+				{
+					$http = JHttpFactory::getHttp();
+					$url  = 'http://ec.europa.eu/taxation_customs/vies/viesquer.do?locale=en'
+						. '&ms=' . urlencode($prefix)
+						. '&iso=' . urlencode($prefix)
+						. '&vat=' . urlencode($vat);
+					
+					for ($i = 0; $i < 2; $i++)
+					{
+						$response = $http->get($url, null, 5);
+						if ($response->code >= 200 && $response->code < 400)
+						{
+							if (preg_match('/invalid VAT number/i', $response->body))
+							{
+								$ret = false;
+								break;
+							}
+							elseif (preg_match('/valid VAT number/i', $response->body))
+							{
+								$ret = true;
+								break;
+							}
+						}
+						else
+						{
+							sleep(1);
+						}
+					}
+				}
+				catch (RuntimeException $e)
+				{
+
+				}
+			}
+
+			if ($ret === null)
+			{
+				$ret = false;
 			}
 		}
 


### PR DESCRIPTION
Make two attempts to validate EU VAT number with SoapClient and if it has failed then make two attempts to fetch webpage with validation result.