### PR TITLE
Fix replacing params when saving subscription in payment plugin

### DIFF
--- a/component/backend/assets/akpayment.php
+++ b/component/backend/assets/akpayment.php
@@ -184,7 +184,7 @@ abstract class plgAkpaymentAbstract extends JPlugin
 	{
 		// Take into account the params->fixdates data to determine when
 		// the new subscription should start and/or expire the old subscription
-		$subcustom = $subscription->params;
+		$subcustom = (!empty($updates['params']) ? $updates['params'] : $subscription->params);
 		if (is_string($subcustom))
 		{
 			$subcustom = json_decode($subcustom, true);


### PR DESCRIPTION
In PayPal plugin on recurring payment there is create param recurring_id on line
https://github.com/akeeba/akeebasubs/blob/4.x/plugins/akpayment/paypal/paypal.php#L321
which is being discarded in method plgAkpaymentAbstract::fixSubscriptionDates