### PR TITLE
Fix replacing params when saving subscription in payment plugin

### DIFF
--- a/component/backend/PluginAbstracts/AkpaymentBase.php
+++ b/component/backend/PluginAbstracts/AkpaymentBase.php
@@ -228,7 +228,7 @@ abstract class AkpaymentBase extends JPlugin
 	{
 		// Take into account the params->fixdates data to determine when
 		// the new subscription should start and/or expire the old subscription
-		$subcustom = $subscription->params;
+		$subcustom = (!empty($updates['params']) ? $updates['params'] : $subscription->params);
 
 		if (is_string($subcustom))
 		{


### PR DESCRIPTION
In PayPal plugin on recurring payment there is create param recurring_id on line
https://github.com/akeeba/akeebasubs/blob/development/plugins/akpayment/paypal/paypal.php#L356
which is being discarded in method AkpaymentBase::fixSubscriptionDates