### PR TITLE
Update astimedrelease.php

### DIFF
--- a/plugins/content/astimedrelease/astimedrelease.php
+++ b/plugins/content/astimedrelease/astimedrelease.php
@@ -440,8 +440,8 @@ class plgContentAstimedrelease extends JPlugin
 
 		if ($paremPos !== false)
 		{
-			$level      = $this->getId(substr($expr, 0, - $paremPos));
-			$expression = substr($expr, - $paremPos);
+			$level      = $this->getId(substr($expr, 0, $paremPos));
+			$expression = substr($expr, $paremPos);
 		}
 		else
 		{


### PR DESCRIPTION
When using {asdaysremaining LEVEL1} with an argument like {asdaysremaining LEVEL1,-10} it will always return '0'. Think, due to the use of negative length.