### PR TITLE
Do not use recurring amount for the first initial payment

### DIFF
--- a/plugins/akpayment/paypal/paypal.php
+++ b/plugins/akpayment/paypal/paypal.php
@@ -240,7 +240,7 @@ class plgAkpaymentPaypal extends AkpaymentBase
 			$mc_gross = floatval($data['mc_gross']);
 
 			// @todo On recurring subscriptions recalculate the net, tax and gross price by removing the signup fee
-			if ($recurring && ($subscription->recurring_amount >= 0.01))
+			if ($recurring && ($subscription->recurring_amount >= 0.01) && $subscription->state != 'N')
 			{
 				$gross = $subscription->recurring_amount;
 			}


### PR DESCRIPTION
First initial PayPal payment have to match the gross amount. The recurring amount should be compared only for recurring payments. When it is an initial payment then the subscription status is NEW and in this case the gross amount have to be used. When there is a recurring amount and it is a second payment (first renewal) then the recurring amount should be used. For the third payment we will use the gross amount as the recurring amount will be set to 0 after the second payment.

This have fixed an issue when: 
- first payment gross amount is lower than recurring amount for next payments
- and first cycle is shorter than recurring cycle