### PR TITLE
Update pkg_akeebasubs.xml since cli removed

### DIFF
--- a/build/templates/pkg_akeebasubs.xml
+++ b/build/templates/pkg_akeebasubs.xml
@@ -18,7 +18,7 @@
         <file type="component" id="com_akeebasubs">com_akeebasubs.zip</file>
 
         <!-- CLI scripts -->
-        <file type="file" id="file_akeebasubs">file_akeebasubs.zip</file>
+        <!-- <file type="file" id="file_akeebasubs">file_akeebasubs.zip</file> -->
 
         <!-- Modules -->
         <file type="module" client="site" id="mod_aksexpires">mod_aksexpires.zip</file>


### PR DESCRIPTION
CLI is removed but there is a following line of code in /build/templates/pkg_akeebasubs.xml
```
<!-- CLI scripts -->
<file type="file" id="file_akeebasubs">file_akeebasubs.zip</file>
```
Although build is successful, package installation fails.

Please remove the code.