### PR TITLE
Handle unsuspended recurring payment

### DIFF
--- a/plugins/akpayment/paypal/paypal.php
+++ b/plugins/akpayment/paypal/paypal.php
@@ -168,7 +168,7 @@ class plgAkpaymentPaypal extends AkpaymentBase
 				$data['txn_type'] = 'workaround_to_missing_txn_type';
 			}
 
-			$validTypes = array('workaround_to_missing_txn_type', 'web_accept', 'recurring_payment', 'subscr_payment');
+			$validTypes = array('workaround_to_missing_txn_type', 'web_accept', 'subscr_payment', 'recurring_payment', 'recurring_payment_outstanding_payment');
 			$isValid = in_array($data['txn_type'], $validTypes);
 
 			if (!$isValid)


### PR DESCRIPTION
When a recurring subscription has been suspended, then there is an option on PayPal to charge outstanding payment if the customer has the cash on his credit card. This generates a new transaction type: recurring_payment_outstanding_payment

```
option com_akeebasubs
view callback
paymentmethod paypal
mc_gross 21.42
outstanding_balance 0.00
next_payment_date 03:00:00 Aug 22, 2017 PDT
protection_eligibility Ineligible
tax 0.00
payer_id xxxxxxxxxxxxx
payment_date 18:24:20 Sep 01, 2016 PDT
payment_status Completed
product_name Contact Form WP updates and support 12M R
charset windows-1250
recurring_payment_id I-xxxxxxxxxxxxxxx
first_name Jane
mc_fee 0.84
notify_version 3.8
custom 1111111
payer_status verified
currency_code EUR
business xxxxxx@perfect-web.co
verify_sign xxxxxxxxxxxxxxxxxxxxxxxxxx
payer_email xxxxxxx@xxxxxx
initial_payment_amount 0.00
profile_status Active
txn_id xxxxxxxxxxxxxxxxx
payment_type instant
last_name Doe
receiver_email xxxxxxxxxxxxx@perfect-web.co
payment_fee
receiver_id xxxxxxxxxxx
txn_type recurring_payment_outstanding_payment
mc_currency EUR
residence_country PL
transaction_subject Contact Form WP updates and support 12M R
payment_gross
shipping 0.00
product_type 1
time_created 14:03:54 Aug 22, 2015 PDT
ipn_track_id xxxxxxxxxxxxxx
```