### PR TITLE
VAT rate does not show on subscribe page

### DIFF
--- a/component/media/js/signup.js
+++ b/component/media/js/signup.js
@@ -910,7 +910,7 @@ function applyPrice(response)
 
 		if ($sumTotalField.length > 0)
 		{
-			var vatContainer = $('#akeebasubs-sum-vat-container');
+			var vatContainer = $('#akeebasubs-vat-container');
 			vatContainer.hide();
 
 			$sumTotalField.text(response.gross);


### PR DESCRIPTION
A wrong ID is used, which causes the VAT container not to show when opening the subscribe page. ("Prices include VAT x%")