### PR TITLE
Added method getFieldValue() to UserInfo\Html

### DIFF
--- a/component/frontend/View/UserInfo/Html.php
+++ b/component/frontend/View/UserInfo/Html.php
@@ -13,5 +13,39 @@ defined('_JEXEC') or die;
 
 class Html extends View
 {
+    /**
+     * Get the value of a field from the session cache. If it's empty use the value from the user parameters cache.
+     *
+     * @param   string  $fieldName    The name of the field
+     * @param   array   $emptyValues  A list of values considered to be "empty" for the purposes of this method
+     *
+     * @return  mixed  The field value
+     */
+    public function getFieldValue($fieldName, array $emptyValues = [])
+    {
+        $cacheValue = null;
+        $userparamsValue = null;
 
+        if (isset($this->cache[$fieldName]))
+        {
+            $cacheValue = $this->cache[$fieldName];
+        }
+
+        if (isset($this->userparams->{$fieldName}))
+        {
+            $userparamsValue = $this->userparams->{$fieldName};
+        }
+
+        if (is_null($cacheValue))
+        {
+            return $userparamsValue;
+        }
+
+        if (!empty($emptyValues) && in_array($cacheValue, $emptyValues))
+        {
+            return $userparamsValue;
+        }
+
+        return $cacheValue;
+    }
 }


### PR DESCRIPTION
There is an error when I try to edit user subscription profile. It is missing **_getFieldValue()_** in _components/com_akeebasubs/View/UserInfo/Html.php_
___
**screenshot 1** (creating menu item)
![menu_item_edit_user_information](https://cloud.githubusercontent.com/assets/1272206/20456744/23c603d8-ae85-11e6-8b04-76f6c175d9bf.png)
___
**screenshot 2** (opening the menu item for editing subscription profile)
![edit_subscription_profile](https://cloud.githubusercontent.com/assets/1272206/20456750/4dfced88-ae85-11e6-9f04-3bcf509dc600.png)
___
**screenshot 3** (error message)
![error_getfieldvalue](https://cloud.githubusercontent.com/assets/1272206/20456745/27249bfc-ae85-11e6-9091-b22cb7b3a801.png)
