### PR TITLE
orders are not auto confirmed after successfull payment by 2conew payment plugin #148

### DIFF
--- a/plugins/akpayment/2conew/2conew.php
+++ b/plugins/akpayment/2conew/2conew.php
@@ -152,7 +152,7 @@ class plgAkpayment2conew extends AkpaymentBase
 			}
 			if (!$isValid)
 			{
-				$data['akeebasubs_failure_reason'] = 'The referenced subscription ID ("merchant_order_id" field) is invalid';
+				$data['akeebasubs_failure_reason'] = 'The referenced subscription ID ("vendor_order_id" field) is invalid';
 			}
 		}
 

--- a/plugins/akpayment/2conew/2conew.php
+++ b/plugins/akpayment/2conew/2conew.php
@@ -132,7 +132,7 @@ class plgAkpayment2conew extends AkpaymentBase
 		// Load the relevant subscription row
 		if ($isValid)
 		{
-			$id = array_key_exists('merchant_order_id', $data) ? (int)$data['merchant_order_id'] : -1;
+			$id = array_key_exists('vendor_order_id', $data) ? (int)$data['vendor_order_id'] : -1;
 			$subscription = null;
 			if ($id > 0)
 			{


### PR DESCRIPTION
Order id is sent to 2checkout using variable "merchant_order_id" and 2checkout returns the order id in INS in the variable "vendor_order_id" and not in "merchant_order_id".

The plugin code expects the order id in the variable "merchant_order_id" which is not sent by 2checkout in INS (send as "vendor_order_id") which is causing trouble in auto confirmation

I referred the INS guide provided by 2checkout

https://www.2checkout.com/static/va/documentation/INS/INS_User_Guide_04_08_2009.pdf