### PR TITLE
Add Password Checks from user Component params

### DIFF
--- a/component/backend/config.xml
+++ b/component/backend/config.xml
@@ -163,6 +163,13 @@
 			<option value="64">COM_AKEEBASUBS_CONFIG_FRONTEND_SUMMARYIMAGES_OPT_MEDIUMIMAGE</option>
 			<option value="128">COM_AKEEBASUBS_CONFIG_FRONTEND_SUMMARYIMAGES_OPT_LARGEIMAGE</option>
 		</field>
+		
+		<field name="apply_joomla_password_requirements" type="list" default="0"
+			   label="COM_AKEEBASUBS_CONFIG_FRONTEND_APPLY_JOOMLA_PASSWORD_REQUIREMENTS_LABEL"
+			   description="COM_AKEEBASUBS_CONFIG_FRONTEND_APPLY_JOOMLA_PASSWORD_REQUIREMENTS_DESC">
+			<option value="0">JNo</option>
+			<option value="1">JYes</option>
+		</field>
 
 		<field name="siteurl" type="hidden" default=""/>
 	</fieldset>

--- a/component/frontend/Model/Subscribe/Validation/Password.php
+++ b/component/frontend/Model/Subscribe/Validation/Password.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 use Akeeba\Subscriptions\Site\Model\Subscribe;
 
+
 /**
  * Validates the password
  *
@@ -41,6 +42,87 @@ class Password extends Base
 
 		// If the two password fields do not match the password validation fails
 		if ($this->state->password != $this->state->password2)
+		{
+			return false;
+		}
+		
+		// If we have parameters from com_users, use those instead.
+		// Some of these may be empty for legacy reasons.
+		$params = ComponentHelper::getParams('com_users');
+
+		if (empty($params))
+		{
+			return true;
+		}
+		
+		$minimumLengthp    = $params->get('minimum_length');
+		$minimumIntegersp  = $params->get('minimum_integers');
+		$minimumSymbolsp   = $params->get('minimum_symbols');
+		$minimumUppercasep = $params->get('minimum_uppercase');
+		$meterp            = $params->get('meter');
+		$thresholdp        = $params->get('threshold');
+
+		empty($minimumLengthp) ? : $minimumLength = (int) $minimumLengthp;
+		empty($minimumIntegersp) ? : $minimumIntegers = (int) $minimumIntegersp;
+		empty($minimumSymbolsp) ? : $minimumSymbols = (int) $minimumSymbolsp;
+		empty($minimumUppercasep) ? : $minimumUppercase = (int) $minimumUppercasep;
+		empty($meterp) ? : $meter = $meterp;
+		empty($thresholdp) ? : $threshold = $thresholdp;
+
+		$valueLength = strlen($value);
+
+		// We set a maximum length to prevent abuse since it is unfiltered.
+		if ($valueLength > 4096)
+		{
+			return false;
+		}
+
+		// We don't allow white space inside passwords
+		$valueTrim = trim($value);
+
+		// Set a variable to check if any errors are made in password
+		$validPassword = true;
+
+		if (strlen($valueTrim) !== $valueLength)
+		{
+			return false;
+		}
+
+		// Minimum number of integers required
+		if (!empty($minimumIntegers))
+		{
+			$nInts = preg_match_all('/[0-9]/', $value, $imatch);
+
+			if ($nInts < $minimumIntegers)
+			{
+				return false;
+			}
+		}
+
+		// Minimum number of symbols required
+		if (!empty($minimumSymbols))
+		{
+			$nsymbols = preg_match_all('[\W]', $value, $smatch);
+
+			if ($nsymbols < $minimumSymbols)
+			{
+				return false;
+			}
+		}
+
+		// Minimum number of upper case ASCII characters required
+		if (!empty($minimumUppercase))
+		{
+			$nUppercase = preg_match_all('/[A-Z]/', $value, $umatch);
+
+			if ($nUppercase < $minimumUppercase)
+			{
+				return false;
+			}
+		}
+
+		// Minimum length option
+		if (!empty($minimumLength))
 		{
 			return false;
 		}

--- a/component/frontend/Model/Subscribe/Validation/Password.php
+++ b/component/frontend/Model/Subscribe/Validation/Password.php
@@ -46,6 +46,12 @@ class Password extends Base
 			return false;
 		}
 		
+		// Check if we need to measure the password strength requirements using Joomla! config
+		if (!$this->container->params->get('apply_joomla_password_requirements', false)) 
+		{
+			return true;
+		}
+		
 		// If we have parameters from com_users, use those instead.
 		// Some of these may be empty for legacy reasons.
 		$params = ComponentHelper::getParams('com_users');

--- a/translations/component/backend/en-GB/en-GB.com_akeebasubs.ini
+++ b/translations/component/backend/en-GB/en-GB.com_akeebasubs.ini
@@ -1102,3 +1102,6 @@ COM_AKEEBASUBS_CONFIG_S3_SIGNATURE_V2="v2 (legacy mode)"
 COM_AKEEBASUBS_ACL_PII_TITLE="Personal Information"
 COM_AKEEBASUBS_ACL_PII_DESC="Access views which can divulge personally identifiable information. Users without this privilege can configure Akeeba Subscriptions but not access subscriptions, invoices etc."
 COM_AKEEBASUBS_COMMON_NO_ACL_PII_FOR_YOU="Access Denied. You are not allowed the “Personal Information” access privilege which is required to access personally identifiable infomration stored in Akeeba Subscriptions."
+
+COM_AKEEBASUBS_CONFIG_FRONTEND_APPLY_JOOMLA_PASSWORD_REQUIREMENTS_LABEL="Apply Joomla! password strength requirements"
+COM_AKEEBASUBS_CONFIG_FRONTEND_APPLY_JOOMLA_PASSWORD_REQUIREMENTS_DESC="User the options set in com_users parameters to evaluate the password strength requirements"


### PR DESCRIPTION
This PR adds the same checks that Joomla\CMS\Form\Rule\PasswordRule implements for the normal com_users component.